### PR TITLE
Fix moment-timezone version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lodash": "^4.17.20",
     "material-design-iconic-font": "^2.2.0",
     "moment": "^2.24.0",
-    "moment-timezone": "@^0.4.0 || ^0.5.0",
+    "moment-timezone": "^0.4.0 || ^0.5.0",
     "nette-forms": "^3.1.8",
     "nette.ajax.js": "^2.3.0",
     "node-waves": "^0.7.6",


### PR DESCRIPTION
Yarn 3 has problem to resolve the version constraint begining with the `@`.