### PR TITLE
Add support for One-Click unsubscribing according to RFC8058

### DIFF
--- a/src/Commands/DatabaseSeedCommand.php
+++ b/src/Commands/DatabaseSeedCommand.php
@@ -47,6 +47,7 @@ class DatabaseSeedCommand extends Command
         $configValues = [
             ['default_mailer', 'Default Mailer', SmtpMailer::ALIAS, '', 'string'],
             [RtmClickReplace::CONFIG_NAME, 'Mail click tracker', false, '', 'boolean'],
+            ['enable_one_click_unsubscribing', 'Enable One-Click Unsubscribing', false, 'Add a header to emails that signals support for One-Click unsubscribe from the newsletter according to RFC 8058. The unsubscribe URL must support the POST method, must immediately unsubscribe the user from the newsletter, must not use redirection or any additional user verification; all the necessary data for unsubscribing must be part of the URL address.', 'boolean']
         ];
         foreach ($configValues as $configValue) {
             $config = $this->configsRepository->findBy('name', $configValue['0']);

--- a/src/Forms/ConfigFormFactory.php
+++ b/src/Forms/ConfigFormFactory.php
@@ -123,7 +123,8 @@ class ConfigFormFactory
                         break;
                     case Config::TYPE_BOOLEAN:
                         $othersContainer->addCheckbox($config['name'], $config['display_name'])
-                            ->setDefaultValue($config['value']);
+                            ->setDefaultValue($config['value'])
+                            ->setOption('description', $config['description']);
                         break;
                     case Config::TYPE_INT:
                         $othersContainer->addText($config['name'], $config['display_name'])

--- a/src/Models/Sender.php
+++ b/src/Models/Sender.php
@@ -9,6 +9,7 @@ use Nette\Utils\AssertionException;
 use Nette\Utils\Json;
 use Psr\Log\LoggerInterface;
 use Remp\MailerModule\Models\Auth\AutoLogin;
+use Remp\MailerModule\Models\Config\Config;
 use Remp\MailerModule\Models\Config\ConfigNotExistsException;
 use Remp\MailerModule\Models\ContentGenerator\ContentGenerator;
 use Remp\MailerModule\Models\ContentGenerator\GeneratorInputFactory;
@@ -40,7 +41,8 @@ class Sender
         private ContentGenerator $contentGenerator,
         private GeneratorInputFactory $generatorInputFactory,
         private ServiceParamsProviderInterface $serviceParamsProvider,
-        private EmailAllowList $emailAllowList
+        private EmailAllowList $emailAllowList,
+        private Config $config
     ) {
     }
 
@@ -350,18 +352,28 @@ class Sender
 
     private function setMessageHeaders(Message $message, $mailSenderId, ?array $templateParams, bool $isBatch = false): void
     {
+        $enableOneClickUnsubscribing = $this->config->get('enable_one_click_unsubscribing');
         if (!$this->template->mail_type->locked) {
             if ($isBatch) {
                 $message->setHeader('List-Unsubscribe', '%recipient.list_unsubscribe%');
+                if ($enableOneClickUnsubscribing) {
+                    $message->setHeader('List-Unsubscribe-Post', '%recipient.list_unsubscribe_post%');
+                }
                 foreach ($templateParams as $email => $variables) {
                     if (isset($variables['unsubscribe'])) {
                         $templateParams[$email]['list_unsubscribe'] = "<{$variables['unsubscribe']}>";
+                        if ($enableOneClickUnsubscribing) {
+                            $templateParams[$email]['list_unsubscribe_post'] = 'List-Unsubscribe=One-Click';
+                        }
                     }
                 }
             } else {
                 foreach ($templateParams as $email => $variables) {
                     if (isset($variables['unsubscribe'])) {
                         $message->setHeader('List-Unsubscribe', "<{$variables['unsubscribe']}>");
+                        if ($enableOneClickUnsubscribing) {
+                            $message->setHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+                        }
                     }
                 }
             }


### PR DESCRIPTION
I would like to add the 'List-Unsubscribe-Post' header to emails according to the RFC8085 standard. I've drafted some code, but I'm unsure whether to send it like this directly or make it configurable in some way. When I looked at the code of the CRM module for the mailer (https://github.com/remp2020/crm-remp-mailer-module/blob/13a06bf1251070fc00a1fae77eb330deb7ad005f/src/Presenters/MailSettingsPresenter.php#L81), it complies with the standard for unsubscribing from newsletters.

More information about the new header:
https://datatracker.ietf.org/doc/html/rfc8058
https://aws.amazon.com/blogs/messaging-and-targeting/an-overview-of-bulk-sender-changes-at-yahoo-gmail/
https://blog.google/products/gmail/gmail-security-authentication-spam-protection/

[Gmail’s FAQ](https://support.google.com/a/answer/14229414#bulk-sender-def&expiration&bulk-sender-comply&email-to-ws&ws-senders&timeline&reqs-not-met&alerts&spam-rate&spam-exceeds&one-click-all-msgs&unsub-msg-body&no-unsub-spam&landing-page&dmarc-align&dmarc-fail&mitigation&&zippy=%2Cwhat-is-the-timeline-for-enforcement-of-sender-guidelines) and [Yahoo’s FAQ](https://senders.yahooinc.com/faqs/) both clarify that the one-click unsubscribe requirement will not be enforced until June 2024 as long as the bulk sender has a functional unsubscribe link clearly visible in the footer of each message.